### PR TITLE
Added link to compose-bloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@
 - [multinavcompose](https://github.com/jeziellago/multinavcompose) - Android multi-module navigation built on top of Jetpack Navigation Compose
 - [compose-backstack](https://github.com/zach-klippenstein/compose-backstack) - Simple composable for rendering transitions between backstacks.
 
+### State Management
+- [compose-bloc](https://github.com/beyondeye/compose_bloc) - State Management and Navigation Library for Jetpack Compose
 
 ## <a name="app-projects"></a> App Projects
 


### PR DESCRIPTION
compose-bloc is a state-management and navigation library for Jetpack compose and compose-multiplatform